### PR TITLE
Migrate to pnpm Catalog Versioning for Consistent Dependency Management

### DIFF
--- a/examples/ai-sdk/package.json
+++ b/examples/ai-sdk/package.json
@@ -13,7 +13,7 @@
     "@ai-sdk/openai": "^1.1.13",
     "ai": "^4.1.42",
     "openai": "^4.85.2",
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/examples/dexter/package.json
+++ b/examples/dexter/package.json
@@ -16,7 +16,7 @@
     "@agentic/stdlib": "workspace:*",
     "@agentic/weather": "workspace:*",
     "@dexaai/dexter": "^4.1.1",
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/examples/genkit/package.json
+++ b/examples/genkit/package.json
@@ -12,7 +12,7 @@
     "@agentic/stdlib": "workspace:*",
     "genkit": "^1.0.4",
     "genkitx-openai": "^0.16.0",
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/examples/langchain/package.json
+++ b/examples/langchain/package.json
@@ -13,7 +13,7 @@
     "@langchain/core": "^0.3.13",
     "@langchain/openai": "0.4.4",
     "langchain": "^0.3.3",
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/examples/llamaindex/package.json
+++ b/examples/llamaindex/package.json
@@ -12,7 +12,7 @@
     "@agentic/llamaindex": "workspace:*",
     "@agentic/stdlib": "workspace:*",
     "llamaindex": "^0.9.2",
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/examples/openai/package.json
+++ b/examples/openai/package.json
@@ -11,7 +11,7 @@
     "@agentic/core": "workspace:*",
     "@agentic/stdlib": "workspace:*",
     "openai": "^4.85.2",
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -11,7 +11,7 @@
     "@agentic/core": "workspace:*",
     "@agentic/stdlib": "workspace:*",
     "restore-cursor": "^5.1.0",
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "turbo": "^2.4.4",
     "typescript": "^5.8.2",
     "vitest": "3.0.7",
-    "zod": "^3.24.2",
+    "zod": "catalog:",
     "zoominfo-api-auth-client": "^1.0.1"
   },
   "lint-staged": {

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -33,11 +33,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/bing/package.json
+++ b/packages/bing/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/calculator/package.json
+++ b/packages/calculator/package.json
@@ -35,7 +35,7 @@
     "mathjs": "^13.0.3"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/clearbit/package.json
+++ b/packages/clearbit/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,15 +35,15 @@
     "dedent": "^1.5.3",
     "delay": "^6.0.0",
     "jsonrepair": "^3.9.0",
-    "ky": "^1.7.5",
+    "ky": "catalog:",
     "openai-zod-to-json-schema": "^1.0.3",
     "p-map": "^7.0.2",
-    "p-throttle": "^6.2.0",
+    "p-throttle": "catalog:",
     "type-fest": "^4.35.0",
     "zod-validation-error": "^3.4.0"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*",

--- a/packages/dexa/package.json
+++ b/packages/dexa/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/diffbot/package.json
+++ b/packages/diffbot/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/e2b/package.json
+++ b/packages/e2b/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "@e2b/code-interpreter": "^1.0.2",
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*",

--- a/packages/exa/package.json
+++ b/packages/exa/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/firecrawl/package.json
+++ b/packages/firecrawl/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -32,12 +32,12 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
+    "ky": "catalog:",
     "octokit": "^4.0.2",
-    "p-throttle": "^6.2.0"
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/gravatar/package.json
+++ b/packages/gravatar/package.json
@@ -33,11 +33,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/hacker-news/package.json
+++ b/packages/hacker-news/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/hunter/package.json
+++ b/packages/hunter/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/jigsawstack/package.json
+++ b/packages/jigsawstack/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   }
 }

--- a/packages/jina/package.json
+++ b/packages/jina/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/leadmagic/package.json
+++ b/packages/leadmagic/package.json
@@ -33,11 +33,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/midjourney/package.json
+++ b/packages/midjourney/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/people-data-labs/package.json
+++ b/packages/people-data-labs/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/perigon/package.json
+++ b/packages/perigon/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/polygon/package.json
+++ b/packages/polygon/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/predict-leads/package.json
+++ b/packages/predict-leads/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/proxycurl/package.json
+++ b/packages/proxycurl/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/rocketreach/package.json
+++ b/packages/rocketreach/package.json
@@ -33,11 +33,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/searxng/package.json
+++ b/packages/searxng/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/serpapi/package.json
+++ b/packages/serpapi/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/serper/package.json
+++ b/packages/serper/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/social-data/package.json
+++ b/packages/social-data/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/stdlib/package.json
+++ b/packages/stdlib/package.json
@@ -76,7 +76,7 @@
     "@e2b/code-interpreter": "^1.0.2"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/tavily/package.json
+++ b/packages/tavily/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/twitter/package.json
+++ b/packages/twitter/package.json
@@ -33,13 +33,13 @@
   "dependencies": {
     "@agentic/core": "workspace:*",
     "@nangohq/node": "^0.42.2",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0",
+    "ky": "catalog:",
+    "p-throttle": "catalog:",
     "twitter-api-sdk": "^1.2.1",
     "type-fest": "^4.35.0"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/weather/package.json
+++ b/packages/weather/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/wikidata/package.json
+++ b/packages/wikidata/package.json
@@ -32,12 +32,12 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0",
+    "ky": "catalog:",
+    "p-throttle": "catalog:",
     "wikibase-sdk": "^10.0.3"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/wikipedia/package.json
+++ b/packages/wikipedia/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/wolfram-alpha/package.json
+++ b/packages/wolfram-alpha/package.json
@@ -32,10 +32,10 @@
   },
   "dependencies": {
     "@agentic/core": "workspace:*",
-    "ky": "^1.7.5"
+    "ky": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*"

--- a/packages/zoominfo/package.json
+++ b/packages/zoominfo/package.json
@@ -34,11 +34,11 @@
   "dependencies": {
     "@agentic/core": "workspace:*",
     "jsrsasign": "^10.9.0",
-    "ky": "^1.7.5",
-    "p-throttle": "^6.2.0"
+    "ky": "catalog:",
+    "p-throttle": "catalog:"
   },
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@agentic/tsconfig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    ky:
+      specifier: ^1.7.5
+      version: 1.7.5
+    p-throttle:
+      specifier: ^6.2.0
+      version: 6.2.0
+    zod:
+      specifier: ^3.24.2
+      version: 3.24.2
+
 importers:
 
   .:
@@ -63,7 +75,7 @@ importers:
         specifier: 3.0.7
         version: 3.0.7(@types/node@22.13.8)(tsx@4.19.3)(yaml@2.7.0)
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
       zoominfo-api-auth-client:
         specifier: ^1.0.1
@@ -87,7 +99,7 @@ importers:
         specifier: ^4.85.2
         version: 4.85.2(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -121,7 +133,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -143,7 +155,7 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0(genkit@1.0.4)(ws@8.18.0)(zod@3.24.2)
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -168,7 +180,7 @@ importers:
         specifier: ^0.3.3
         version: 0.3.19(@langchain/core@0.3.40(openai@4.85.3(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)))(axios@1.7.9)(encoding@0.1.13)(handlebars@4.7.8)(openai@4.85.3(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2))(ws@8.18.0)
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -190,7 +202,7 @@ importers:
         specifier: ^0.9.2
         version: 0.9.2(@aws-crypto/sha256-js@5.2.0)(encoding@0.1.13)(js-tiktoken@1.0.19)(pathe@1.1.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(ws@8.18.0)(zod@3.24.2)
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -209,7 +221,7 @@ importers:
         specifier: ^4.85.2
         version: 4.85.2(encoding@0.1.13)(ws@8.18.0)(zod@3.24.2)
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -228,7 +240,7 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -254,13 +266,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -273,10 +285,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -292,7 +304,7 @@ importers:
         specifier: ^13.0.3
         version: 13.2.3
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -305,13 +317,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -330,7 +342,7 @@ importers:
         specifier: ^3.9.0
         version: 3.12.0
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       openai-zod-to-json-schema:
         specifier: ^1.0.3
@@ -339,13 +351,13 @@ importers:
         specifier: ^7.0.2
         version: 7.0.3
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       type-fest:
         specifier: ^4.35.0
         version: 4.35.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
       zod-validation-error:
         specifier: ^3.4.0
@@ -364,13 +376,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -396,13 +408,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -415,7 +427,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -431,10 +443,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -447,13 +459,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -479,16 +491,16 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       octokit:
         specifier: ^4.0.2
         version: 4.1.2
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -501,13 +513,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -520,10 +532,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -536,10 +548,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -549,10 +561,10 @@ importers:
   packages/jigsawstack:
     dependencies:
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
     devDependencies:
       '@agentic/core':
@@ -574,13 +586,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -606,13 +618,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -638,10 +650,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -654,10 +666,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -670,13 +682,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -689,13 +701,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -708,10 +720,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -724,13 +736,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -743,13 +755,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -762,13 +774,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -781,10 +793,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -797,10 +809,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -813,10 +825,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -829,10 +841,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -845,13 +857,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -990,7 +1002,7 @@ importers:
         specifier: ^1.0.2
         version: 1.0.4
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -1003,13 +1015,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -1024,10 +1036,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -1043,10 +1055,10 @@ importers:
         specifier: ^0.42.2
         version: 0.42.22
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       twitter-api-sdk:
         specifier: ^1.2.1
@@ -1055,7 +1067,7 @@ importers:
         specifier: ^4.35.0
         version: 4.35.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -1068,10 +1080,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -1084,16 +1096,16 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       wikibase-sdk:
         specifier: ^10.0.3
         version: 10.2.1
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -1106,13 +1118,13 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -1125,10 +1137,10 @@ importers:
         specifier: workspace:*
         version: link:../core
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':
@@ -1144,13 +1156,13 @@ importers:
         specifier: ^10.9.0
         version: 10.9.0
       ky:
-        specifier: ^1.7.5
+        specifier: 'catalog:'
         version: 1.7.5
       p-throttle:
-        specifier: ^6.2.0
+        specifier: 'catalog:'
         version: 6.2.0
       zod:
-        specifier: ^3.24.2
+        specifier: 'catalog:'
         version: 3.24.2
     devDependencies:
       '@agentic/tsconfig':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+catalog:
+  ky: '^1.7.5'
+  p-throttle: '^6.2.0'
+  zod: '^3.24.2'
+
 packages:
   - 'packages/*'
   - 'examples/*'


### PR DESCRIPTION
This PR standardizes our dependency management by leveraging pnpm workspace catalog versioning. Instead of hardcoding version numbers in each package.json file, we now reference a centralized version catalog.

Why this change?
- Consistency: Ensures all packages use the same version of shared dependencies
- Maintainability: Simplifies dependency updates - change once in the catalog instead of in multiple package.json files
- Reduced Conflicts: Minimizes version conflicts and dependency hell across the workspace
- Better Contributor Experience: Makes it easier for new contributors to understand our dependency structure

This approach follows modern monorepo best practices and will make our dependency management more robust as the project grows. It also reduces the cognitive overhead when updating dependencies, as developers only need to update versions in a single location.

The change is non-breaking and should make future dependency maintenance easier for all contributors.