### PR TITLE
docs: add ModelFetch guide for publishing MCP servers

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,7 @@
             "pages": [
               "publishing/guides/existing-mcp-server",
               "publishing/guides/existing-openapi-service",
+              "publishing/guides/ts-modelfetch",
               "publishing/guides/ts-fastmcp",
               "publishing/guides/ts-mcp-hono",
               "publishing/guides/ts-openapi-hono",

--- a/docs/publishing/guides/ts-modelfetch.mdx
+++ b/docs/publishing/guides/ts-modelfetch.mdx
@@ -1,0 +1,86 @@
+---
+title: TypeScript ModelFetch
+description: This guide will show you how to publish an MCP server to Agentic using ModelFetch.
+---
+
+[ModelFetch](https://www.modelfetch.com) is a TypeScript/JavaScript SDK designed for building and deploying MCP servers across multiple runtime environments.
+
+## 1. Create a ModelFetch MCP server
+
+<Info>
+  **Prerequisite**: Please install [Node.js](https://nodejs.org) before
+  proceeding.
+</Info>
+
+```bash
+npx -y create-modelfetch@latest
+```
+
+Follow the interactive prompts to:
+1. **Choosing a runtime** - Node.js, Bun, Deno, Cloudflare Workers, or Vercel Functions
+2. **Selecting a language** - TypeScript or JavaScript
+3. **Picking a package manager** - npm, pnpm, bun, or yarn
+
+Then navigate to your project:
+
+```bash
+cd my-mcp-server
+```
+
+## 2. Implement your MCP server
+
+Edit the server file to add your MCP tools, resources, and prompts:
+
+```ts server.ts
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+
+const server = new McpServer({
+  title: 'My MCP Server',
+  name: 'my-mcp-server',
+  version: '1.0.0',
+})
+
+server.registerTool(
+  'add',
+  {
+    title: 'Add Numbers',
+    description: 'Add two numbers together',
+    inputSchema: {
+      a: z.number(),
+      b: z.number(),
+    },
+  },
+  ({ a, b }) => ({
+    content: [{
+      type: 'text',
+      text: `${a} + ${b} = ${a + b}`,
+    }],
+  })
+)
+
+export default server
+```
+
+<Note>
+  [ModelFetch](https://www.modelfetch.com) uses the [official MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) and provides runtime-specific handlers for different platforms.
+</Note>
+
+## 3. Deploy your MCP server remotely
+
+ModelFetch supports multiple deployment targets. Deploy your server to any platforms that support these runtimes:
+
+- [Node.js](https://www.modelfetch.com/docs/runtimes/node)
+- [Bun](https://www.modelfetch.com/docs/runtimes/bun)
+- [Deno](https://www.modelfetch.com/docs/runtimes/deno)
+- [Cloudflare](https://www.modelfetch.com/docs/runtimes/cloudflare)
+- [Vercel](https://www.modelfetch.com/docs/runtimes/vercel)
+
+<Warning>
+  For development, you can use [ngrok](https://ngrok.com) to temporarily expose your local server. Only
+  use this in a safe environment as it exposes your server to the internet.
+</Warning>
+
+## 4. Deploy your origin MCP server to Agentic
+
+Now that you have a publicly available MCP server, you can follow the [existing MCP server guide](/publishing/guides/existing-mcp-server) to deploy it to Agentic.

--- a/docs/publishing/quickstart.mdx
+++ b/docs/publishing/quickstart.mdx
@@ -29,6 +29,14 @@ description: Deploy your first MCP product to Agentic in minutes.
 <Tab title="TypeScript">
 <Columns cols={2}>
   <Card
+    title='TS ModelFetch'
+    href='/publishing/guides/ts-modelfetch'
+    icon='cube-transparent'
+  >
+    Create a new MCP server and deploy it to Agentic using ModelFetch SDK.
+  </Card>
+
+  <Card
     title='TS FastMCP Server'
     href='/publishing/guides/ts-fastmcp'
     icon='bolt'


### PR DESCRIPTION
## Summary
- Added new guide for creating MCP servers with ModelFetch SDK
- Updated quickstart to include ModelFetch as first TypeScript option
- Added navigation entry in docs.json

## Test plan
- [x] Verified markdown formatting is consistent with other guides
- [x] Checked all links are correct
- [x] Ensured guide follows the same structure as other MCP guides

🤖 Generated with [Claude Code](https://claude.ai/code)